### PR TITLE
Install the shared dotfiles for everyone

### DIFF
--- a/modules/people/manifests/jacebrowning.pp
+++ b/modules/people/manifests/jacebrowning.pp
@@ -3,19 +3,19 @@ class people::jacebrowning {
   # Shell
   include zsh
   include ohmyzsh
-  repository { "/Users/${::boxen_user}/.dotfiles":
-      source => 'jacebrowning/dotfiles',
-      provider => git,
-      ensure   => 'origin/HEAD',
+  $dotfiles_custom = "/Users/${::boxen_user}/.dotfiles-custom"
+  repository { $dotfiles_custom:
+    source => 'jacebrowning/dotfiles',
+    provider => git,
+    ensure   => 'origin/HEAD',
   }
-  $dotfiles =  "${boxen::config::srcdir}/dotfiles"
-  file { $dotfiles:
+  exec { "install custom dotfiles":
+    require => Repository[$dotfiles_custom],
+    command => "/usr/bin/make -C $dotfiles_custom"
+  }
+  file { "${boxen::config::srcdir}/dotfiles-custom":
     ensure => link,
-    target => "/Users/${::boxen_user}/.dotfiles"
-  }
-  exec { "install dotfiles":
-    require => File[$dotfiles],
-    command => "/usr/bin/make -C /Users/${::boxen_user}/.dotfiles"
+    target => "/Users/${::boxen_user}/.dotfiles-custom"
   }
 
   # Terminal

--- a/modules/people/manifests/modustri_ci.pp
+++ b/modules/people/manifests/modustri_ci.pp
@@ -3,20 +3,6 @@ class people::modustri_ci {
   # Shell
   include zsh
   include ohmyzsh
-  repository { "/Users/${::boxen_user}/.dotfiles":
-    source => 'modustri/dotfiles',
-    provider => git,
-    ensure   => 'origin/HEAD',
-  }
-  $dotfiles =  "${boxen::config::srcdir}/dotfiles"
-  file { $dotfiles:
-    ensure => link,
-    target => "/Users/${::boxen_user}/.dotfiles"
-  }
-  exec { "install dotfiles":
-    require => File[$dotfiles],
-    command => "/usr/bin/make -C /Users/${::boxen_user}/.dotfiles"
-  }
   git::config::global { 'color.ui':
     value  => 'false'
   }


### PR DESCRIPTION
@Ross-Hunter I think this will have the desired effect we're looking for. It will automatically install https://github.com/modustri/dotfiles for everyone running boxen but allow people to maintain their own dotfiles directory (as I have done in `jacebrowning.pp`) that gets "merged" with the shared one:

<img width="508" alt="screen shot 2016-04-16 at 12 27 11 pm" src="https://cloud.githubusercontent.com/assets/939501/14582275/a2685d7e-03ce-11e6-9d48-f61c2d1c804a.png">
